### PR TITLE
Add docker user option to example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example
 
 ```bash
 mkdir petstore && cd petstore
-docker run -v $(pwd):/code swaggest/swac swac php-guzzle-client https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore.json --namespace MyApp\\Petstore
+docker run -v $(pwd):/code -u 1000:1000 swaggest/swac swac php-guzzle-client https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore.json --namespace MyApp\\Petstore
 ```
 
 ### Composer


### PR DESCRIPTION
On Linux, files generated by the tool have the owner as root:root. To avoid it add -u 1000:1000 which means files generated by current user